### PR TITLE
Add a sample stretching function

### DIFF
--- a/include/lsp-plug.in/dsp-units/sampling/Sample.h
+++ b/include/lsp-plug.in/dsp-units/sampling/Sample.h
@@ -176,6 +176,14 @@ namespace lsp
                  */
                 bool resize(size_t channels, size_t max_length, size_t length = 0);
 
+                /** Stretch sample
+                 *
+                 * @param stretch_samples samples to stretch
+                 * @param chunk_size chunk size multiplier
+                 * @return true if data was successfuly stretched
+                 */
+                bool stretch(ssize_t stretch_samples, size_t chunk_size, size_t start, size_t end, float fade_size);
+
                 /** Resize sample to match the specified number of audio channels,
                  * all previously allocated data will be kept
                  *

--- a/src/test/utest/sampling/sample.cpp
+++ b/src/test/utest/sampling/sample.cpp
@@ -75,6 +75,32 @@ UTEST_BEGIN("dspu.sampling", sample)
         }
     }
 
+    void test_stretch()
+    {
+        printf("Testing sample stretch...\n");
+
+        dspu::Sample sampl;
+        init_sample(&sampl);
+
+        ssize_t stretch_values [] = { 1000, -1000 };
+        size_t chunk_sizes [] = { 50, 125, 250, 500, 775 };
+        size_t start_values [] = { 0, 500, 1000 };
+        size_t end_values [] = { sampl.length(), sampl.length()-500, sampl.length()-1000 };
+        float fade_sizes [] = { 100.0f, 75.0f, 50.0f, 25.0f, 0.0f };
+
+        for (size_t sc = 0; sc < *(&stretch_values + 1) - stretch_values; sc++) {
+            for (size_t c = 0; c < *(&chunk_sizes + 1) - chunk_sizes; c++) {
+                for (size_t s = 0; s < *(&start_values + 1) - start_values; s++) {
+                    for (size_t e = 0; e < *(&end_values + 1) - end_values; e++) {
+                        for (size_t f = 0; f < *(&fade_sizes + 1) - fade_sizes; f++) {
+                          UTEST_ASSERT(sampl.stretch(stretch_values[sc], chunk_sizes[c], start_values[s], end_values[e], fade_sizes[f]) == STATUS_OK);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     void test_io()
     {
         printf("Testing save & load for Sample...\n");


### PR DESCRIPTION
In this function time stretching is achieved by allocating a buffer with a desired length and copying chunks from the original pitch shifted sample. Chunks are selected or duplicated based on `stretch_ratio` - a ratio between the number of chunks in the original sample and the destination sample. Each chunk cross fades with each other to smoothen the results. 

### This illustrates how this function would stretch down:

1. Select chunks based on stretch ratio
![g12254](https://user-images.githubusercontent.com/8728677/178145021-5d9ac231-58a4-484e-a9af-6cb0656f65c4.png)
     - selected chunks:
![g12287](https://user-images.githubusercontent.com/8728677/178145255-f9c7b683-0b2c-40db-8d9b-90fde9afdcf9.png)

2. Cross fade chunks
![g1099](https://user-images.githubusercontent.com/8728677/178145322-8024a14f-3d7e-489e-a393-84ab06edc898.png)

3. Copy chunks to the destination sample
![g1144](https://user-images.githubusercontent.com/8728677/178145414-b68ce10c-8fec-4331-a72a-ca0e71a1d1ed.png)

I'm not really sure if you can call that cross fading though... This technique works quite well when stretching down. Unfortunately when stretching up the result is least pleasant to the ear. Sudden sound like percussion make the samples kinda "ruined". Changing `chunk_size` sometimes helps though.

Anyway I think it's a good start for the implementation of this very useful feature. Let me know if you see any flaws or have any ideas on how I could improve this! :)